### PR TITLE
Install fails on Python 2.6

### DIFF
--- a/alignment/profile.py
+++ b/alignment/profile.py
@@ -32,7 +32,7 @@ class SoftElement(object):
 
     def probabilities(self):
         t = sum(self.__weights.itervalues())
-        return {e: float(w) / t for e, w in self.__weights.iteritems()}
+        return dict(e, float(w) / t,) for e, w in self.__weights.iteritems())
 
     def toDict(self):
         return self.__weights


### PR DESCRIPTION
Eser:
The install fails on Python 2.6 9see trace below). This is due to the use of a dict comprehension which is supported in 2.7 and up only. The proposed mini patch fixes this by using a regular dict constructor to the same effect.

```
$ pip install alignment
Downloading/unpacking alignment
  Downloading alignment-1.0.8.tar.gz
  Running setup.py egg_info for package alignment
Installing collected packages: alignment
  Running setup.py install for alignment
    SyntaxError: ('invalid syntax', ('/home/pombredanne/align/lib/python2.6/site-packages/alignment/profile.py', 35, 35, '        return {e: float(w) / t for e
 w in self.__weights.iteritems()}\n'))

Successfully installed alignment
```
