### PR TITLE
Make it possible to override gap_element

### DIFF
--- a/alignment/vocabulary.py
+++ b/alignment/vocabulary.py
@@ -9,9 +9,13 @@ from .profile import Profile
 # Vocabulary ------------------------------------------------------------------
 
 class Vocabulary(object):
-    def __init__(self):
-        self.__elementToCode = {GAP_ELEMENT: GAP_CODE}
-        self.__codeToElement = {GAP_CODE: GAP_ELEMENT}
+    def __init__(self, gap_code=None, gap_element=None):
+        if gap_code is None:
+            gap_code = GAP_CODE
+        if gap_element is None:
+            gap_element = GAP_ELEMENT
+        self.__elementToCode = {gap_element: gap_code}
+        self.__codeToElement = {gap_code: gap_element}
 
     def has(self, element):
         return element in self.__elementToCode


### PR DESCRIPTION
`'-'` as a gap element doesn't work for my project.

Currently, I am doing the following, but it seems pretty hack-ish:

```python
import alignment
alignment.vocabulary.GAP_ELEMENT = '∅'
```

This pull request would make it possible to define these values when initializing the `Vocabulary`, like this `Vocabulary(gap_element='∅')`.

I don't understand why `GAP_ELEMENT` is defined in a different file. Maybe you don't need the constants at all, and just have defaults in the `__init__()`.